### PR TITLE
Remove UTF8BOM

### DIFF
--- a/commonItems/CommonFunctions.cs
+++ b/commonItems/CommonFunctions.cs
@@ -3,7 +3,6 @@ using System.Text;
 
 namespace commonItems {
     public static class CommonFunctions {
-        public static string UTF8BOM { get; } = "\xEF\xBB\xBF";
         public static string TrimPath(string fileName) {
             string trimmedFileName = fileName;
             var lastSlash = trimmedFileName.LastIndexOf('\\');


### PR DESCRIPTION
After using it in ImperatorToCK3 I know it didn't work (probably because the string is UTF16). 
Use [StreamWriter(stream, System.Text.Encoding.UTF8)](https://docs.microsoft.com/pl-pl/dotnet/api/system.io.streamwriter.-ctor?view=net-5.0#System_IO_StreamWriter__ctor_System_IO_Stream_System_Text_Encoding_) instead, it adds BOM.