### PR TITLE
Move variables dictionary from Parser to BufferedReader

### DIFF
--- a/commonItems.UnitTests/BufferedReaderTests.cs
+++ b/commonItems.UnitTests/BufferedReaderTests.cs
@@ -44,14 +44,13 @@ namespace commonItems.UnitTests {
 		[Fact]
 		public void EndOfStreamIsFalseIfThereAreCharactersInStack() {
 			var reader = new BufferedReader("token");
-			var parser = new Parser();
-			parser.GetNextTokenWithoutMatching(reader);
+			Parser.GetNextTokenWithoutMatching(reader);
 			Assert.True(reader.EndOfStream);
 			reader.PushBack('e');
 			reader.PushBack('v');
 			reader.PushBack('a');
 			Assert.False(reader.EndOfStream);
-			Assert.Equal("ave", parser.GetNextTokenWithoutMatching(reader));
+			Assert.Equal("ave", Parser.GetNextTokenWithoutMatching(reader));
 			Assert.True(reader.EndOfStream);
 		}
 

--- a/commonItems.UnitTests/CommonRegexesTests.cs
+++ b/commonItems.UnitTests/CommonRegexesTests.cs
@@ -8,7 +8,7 @@ namespace commonItems.UnitTests {
 			var reader = new BufferedReader("@ai_aggressiveness = 70");
 			var instance = new TestParser();
 			instance.ParseStream(reader);
-			Assert.Collection(instance.Variables,
+			Assert.Collection(reader.Variables,
 				pair => {
 					var (key, value) = pair;
 					Assert.Equal("ai_aggressiveness", key);
@@ -21,7 +21,7 @@ namespace commonItems.UnitTests {
 			var reader = new BufferedReader("@[100-ai_aggressiveness] = 70");
 			var instance = new TestParser();
 			instance.ParseStream(reader);
-			Assert.Empty(instance.Variables);
+			Assert.Empty(reader.Variables);
 		}
 
 		[Fact]

--- a/commonItems.UnitTests/ParserHelperTests.cs
+++ b/commonItems.UnitTests/ParserHelperTests.cs
@@ -640,17 +640,17 @@ namespace commonItems.UnitTests {
 			public Dictionary<string, string> assignments = new();
 
 			public TypeClass(BufferedReader reader) {
-				RegisterKeyword("str", reader => str = reader.GetString(Variables));
-				RegisterKeyword("integer", reader => integer = reader.GetInt(Variables));
-				RegisterKeyword("longInt", reader => longInt = reader.GetLong(Variables));
-				RegisterKeyword("ulongInt", reader => ulongInt = reader.GetULong(Variables));
-				RegisterKeyword("d", reader => d = reader.GetDouble(Variables));
-				RegisterKeyword("strings", reader => strings = reader.GetStrings(Variables));
-				RegisterKeyword("ints", reader => ints = reader.GetInts(Variables));
-				RegisterKeyword("longs", reader => longs = reader.GetLongs(Variables));
-				RegisterKeyword("ulongs", reader => ulongs = reader.GetULongs(Variables));
-				RegisterKeyword("doubles", reader => doubles = reader.GetDoubles(Variables));
-				RegisterKeyword("assignments", reader => assignments = reader.GetAssignments(Variables));
+				RegisterKeyword("str", reader => str = reader.GetString());
+				RegisterKeyword("integer", reader => integer = reader.GetInt());
+				RegisterKeyword("longInt", reader => longInt = reader.GetLong());
+				RegisterKeyword("ulongInt", reader => ulongInt = reader.GetULong());
+				RegisterKeyword("d", reader => d = reader.GetDouble());
+				RegisterKeyword("strings", reader => strings = reader.GetStrings());
+				RegisterKeyword("ints", reader => ints = reader.GetInts());
+				RegisterKeyword("longs", reader => longs = reader.GetLongs());
+				RegisterKeyword("ulongs", reader => ulongs = reader.GetULongs());
+				RegisterKeyword("doubles", reader => doubles = reader.GetDoubles());
+				RegisterKeyword("assignments", reader => assignments = reader.GetAssignments());
 
 				ParseStream(reader);
 			}

--- a/commonItems.UnitTests/ParserTests.cs
+++ b/commonItems.UnitTests/ParserTests.cs
@@ -299,8 +299,8 @@ namespace commonItems.UnitTests {
 			public double Prestige { get; private set; }
 
 			public TestCountry(BufferedReader reader) {
-				RegisterKeyword("name", reader => Name = reader.GetString(Variables));
-				RegisterKeyword("prestige", reader => Prestige = reader.GetDouble(Variables));
+				RegisterKeyword("name", reader => Name = reader.GetString());
+				RegisterKeyword("prestige", reader => Prestige = reader.GetDouble());
 				ParseStream(reader);
 			}
 		}

--- a/commonItems/BufferedReader.cs
+++ b/commonItems/BufferedReader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NCalc;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -123,8 +124,8 @@ namespace commonItems {
 			var assignments = new Dictionary<string, string>();
 			var parser = new Parser();
 			parser.RegisterRegex(CommonRegexes.Catchall, (reader, assignmentName) => {
-				parser.GetNextTokenWithoutMatching(reader); // remove equals
-				var assignmentValue = parser.GetNextTokenWithoutMatching(reader);
+				Parser.GetNextTokenWithoutMatching(reader); // remove equals
+				var assignmentValue = Parser.GetNextTokenWithoutMatching(reader);
 				if (assignmentValue is null) {
 					throw new FormatException($"Cannot assign null to {assignmentName}!");
 				}
@@ -132,6 +133,20 @@ namespace commonItems {
 			});
 			parser.ParseStream(this);
 			return assignments;
+		}
+
+		public Dictionary<string, object> Variables { get; } = new();
+
+		public object ResolveVariable(string lexeme) {
+			return Variables[lexeme[1..]];
+		}
+
+		public object EvaluateExpression(string lexeme) {
+			var expression = new Expression(lexeme[2..^1]);
+			foreach (var (name, value) in Variables) {
+				expression.Parameters[name] = value;
+			}
+			return expression.Evaluate();
 		}
 	}
 }

--- a/commonItems/BufferedReader.cs
+++ b/commonItems/BufferedReader.cs
@@ -26,13 +26,11 @@ namespace commonItems {
 		private readonly Stack<int> characterStack = new();
 
 		public int Read() {
-			int ch;
 			if (characterStack.TryPop(out int character)) {
-				ch = character;
+				return character;
 			} else {
-				ch = streamReader.Read();  // could be -1 
+				return streamReader.Read();  // could be -1 
 			}
-			return ch;
 		}
 
 		public string Read(uint numberOfChars) {
@@ -84,35 +82,35 @@ namespace commonItems {
 			characterStack.Push(ch);
 		}
 
-		public string GetString(Dictionary<string, object>? variables = null) {
-			return new SingleString(this, variables).String;
+		public string GetString() {
+			return new SingleString(this).String;
 		}
-		public int GetInt(Dictionary<string, object>? variables = null) {
-			return new SingleInt(this, variables).Int;
+		public int GetInt() {
+			return new SingleInt(this).Int;
 		}
-		public long GetLong(Dictionary<string, object>? variables = null) {
-			return new SingleLong(this, variables).Long;
+		public long GetLong() {
+			return new SingleLong(this).Long;
 		}
-		public ulong GetULong(Dictionary<string, object>? variables = null) {
-			return new SingleULong(this, variables).ULong;
+		public ulong GetULong() {
+			return new SingleULong(this).ULong;
 		}
-		public double GetDouble(Dictionary<string, object>? variables = null) {
-			return new SingleDouble(this, variables).Double;
+		public double GetDouble() {
+			return new SingleDouble(this).Double;
 		}
-		public List<string> GetStrings(Dictionary<string, object>? variables = null) {
-			return new StringList(this, variables).Strings;
+		public List<string> GetStrings() {
+			return new StringList(this).Strings;
 		}
-		public List<int> GetInts(Dictionary<string, object>? variables = null) {
-			return new IntList(this, variables).Ints;
+		public List<int> GetInts() {
+			return new IntList(this).Ints;
 		}
-		public List<long> GetLongs(Dictionary<string, object>? variables = null) {
-			return new LongList(this, variables).Longs;
+		public List<long> GetLongs() {
+			return new LongList(this).Longs;
 		}
-		public List<ulong> GetULongs(Dictionary<string, object>? variables = null) {
-			return new ULongList(this, variables).ULongs;
+		public List<ulong> GetULongs() {
+			return new ULongList(this).ULongs;
 		}
-		public List<double> GetDoubles(Dictionary<string, object>? variables = null) {
-			return new DoubleList(this, variables).Doubles;
+		public List<double> GetDoubles() {
+			return new DoubleList(this).Doubles;
 		}
 		public StringOfItem GetStringOfItem() {
 			return new StringOfItem(this);
@@ -121,9 +119,9 @@ namespace commonItems {
 			return new PDXBool(this);
 		}
 
-		public Dictionary<string, string> GetAssignments(Dictionary<string, object>? variables = null) {
+		public Dictionary<string, string> GetAssignments() {
 			var assignments = new Dictionary<string, string>();
-			var parser = new Parser(variables);
+			var parser = new Parser();
 			parser.RegisterRegex(CommonRegexes.Catchall, (reader, assignmentName) => {
 				parser.GetNextTokenWithoutMatching(reader); // remove equals
 				var assignmentValue = parser.GetNextTokenWithoutMatching(reader);

--- a/commonItems/ColorFactory.cs
+++ b/commonItems/ColorFactory.cs
@@ -6,10 +6,9 @@ namespace commonItems {
 	public class ColorFactory {
 		public Dictionary<string, Color> NamedColors { get; } = new();
 		public Color GetColor(BufferedReader reader) {
-			var parser = new Parser();
-			parser.GetNextTokenWithoutMatching(reader); // equals sign
+			Parser.GetNextTokenWithoutMatching(reader); // equals sign
 
-			var token = parser.GetNextTokenWithoutMatching(reader);
+			var token = Parser.GetNextTokenWithoutMatching(reader);
 			if (token is null) {
 				throw new FormatException("Cannot get color without token");
 			}

--- a/commonItems/Parser.cs
+++ b/commonItems/Parser.cs
@@ -76,23 +76,18 @@ namespace commonItems {
 
 		public Parser() {
 			registeredRules[new RegisteredRegex(CommonRegexes.Variable)] = new TwoArgDelegate((reader, varStr) => {
-				var value = reader.GetString(Variables);
+				var value = reader.GetString();
+				var variableName = varStr[1..];
 				if (int.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out int intValue)) {
-					Variables.Add(varStr[1..], intValue);
+					Variables.Add(variableName, intValue);
 					return;
 				}
 				if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out double doubleValue)) {
-					Variables.Add(varStr[1..], doubleValue);
+					Variables.Add(variableName, doubleValue);
 					return;
 				}
-				Variables.Add(varStr[1..], value);
+				Variables.Add(variableName, value);
 			});
-		}
-
-		public Parser(Dictionary<string, object>? variables) : this() {
-			if (variables is not null) {
-				Variables = variables;
-			}
 		}
 
 		public static void AbsorbBOM(BufferedReader reader) {

--- a/commonItems/Parser.cs
+++ b/commonItems/Parser.cs
@@ -1,5 +1,4 @@
-﻿using NCalc;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -34,8 +33,6 @@ namespace commonItems {
 	}
 
 	public class Parser {
-		public Dictionary<string, object> Variables { get; } = new();
-
 		private abstract class RegisteredKeywordOrRegex : IEquatable<RegisteredKeywordOrRegex> {
 			public abstract bool Equals(RegisteredKeywordOrRegex? other);
 			public abstract bool Matches(string token);
@@ -79,14 +76,14 @@ namespace commonItems {
 				var value = reader.GetString();
 				var variableName = varStr[1..];
 				if (int.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out int intValue)) {
-					Variables.Add(variableName, intValue);
+					reader.Variables.Add(variableName, intValue);
 					return;
 				}
 				if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out double doubleValue)) {
-					Variables.Add(variableName, doubleValue);
+					reader.Variables.Add(variableName, doubleValue);
 					return;
 				}
-				Variables.Add(variableName, value);
+				reader.Variables.Add(variableName, value);
 			});
 		}
 
@@ -247,31 +244,19 @@ namespace commonItems {
 			return sb.ToString();
 		}
 
-		public object ResolveVariable(string lexeme) {
-			return Variables[lexeme[1..]];
-		}
-
-		public object EvaluateExpression(string lexeme) {
-			var expression = new Expression(lexeme[2..^1]);
-			foreach (var (name, value) in Variables) {
-				expression.Parameters[name] = value;
-			}
-			return expression.Evaluate();
-		}
-
 		// WithoutMatching refers to not matching against registered rules.
 		// Here we are only matching against variable and interpolated expression regexes
 		// to resolve them before returning.
-		public string? GetNextTokenWithoutMatching(BufferedReader reader) {
+		public static string? GetNextTokenWithoutMatching(BufferedReader reader) {
 			if (reader.EndOfStream) {
 				return null;
 			}
 			var lexeme = GetNextLexeme(reader);
 			if (CommonRegexes.Variable.IsMatch(lexeme)) {
-				return GetValueString(ResolveVariable(lexeme));
+				return GetValueString(reader.ResolveVariable(lexeme));
 			}
 			if (CommonRegexes.InterpolatedExpression.IsMatch(lexeme)) {
-				return GetValueString(EvaluateExpression(lexeme));
+				return GetValueString(reader.EvaluateExpression(lexeme));
 			}
 			return lexeme;
 

--- a/commonItems/ParserHelpers.cs
+++ b/commonItems/ParserHelpers.cs
@@ -43,8 +43,8 @@ namespace commonItems {
 		}
 	}
 	public class SingleString {
-		public SingleString(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var parser = new Parser(variables);
+		public SingleString(BufferedReader sr) {
+			var parser = new Parser();
 			// remove equals
 			parser.GetNextTokenWithoutMatching(sr);
 
@@ -59,8 +59,8 @@ namespace commonItems {
 	}
 
 	public class SingleInt {
-		public SingleInt(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var intStr = StringUtils.RemQuotes(sr.GetString(variables));
+		public SingleInt(BufferedReader sr) {
+			var intStr = StringUtils.RemQuotes(sr.GetString());
 			if (!int.TryParse(intStr, out int theInt)) {
 				Logger.Warn($"Could not convert string {intStr} to int!");
 				return;
@@ -71,8 +71,8 @@ namespace commonItems {
 	}
 
 	public class SingleLong {
-		public SingleLong(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var longStr = StringUtils.RemQuotes(sr.GetString(variables));
+		public SingleLong(BufferedReader sr) {
+			var longStr = StringUtils.RemQuotes(sr.GetString());
 			if (!long.TryParse(longStr, out long theLong)) {
 				Logger.Warn($"Could not convert string {longStr} to long!");
 				return;
@@ -83,8 +83,8 @@ namespace commonItems {
 	}
 
 	public class SingleULong {
-		public SingleULong(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var ulongStr = StringUtils.RemQuotes(sr.GetString(variables));
+		public SingleULong(BufferedReader sr) {
+			var ulongStr = StringUtils.RemQuotes(sr.GetString());
 			if (!ulong.TryParse(ulongStr, out ulong theULong)) {
 				Logger.Warn($"Could not convert string {ulongStr} to ulong!");
 				return;
@@ -95,8 +95,8 @@ namespace commonItems {
 	}
 
 	public class SingleDouble {
-		public SingleDouble(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var doubleStr = StringUtils.RemQuotes(sr.GetString(variables));
+		public SingleDouble(BufferedReader sr) {
+			var doubleStr = StringUtils.RemQuotes(sr.GetString());
 			if (!double.TryParse(doubleStr, NumberStyles.Any, CultureInfo.InvariantCulture, out double theDouble)) {
 				Logger.Warn($"Could not convert string {doubleStr} to double!");
 				return;
@@ -107,20 +107,12 @@ namespace commonItems {
 	}
 
 	public class StringList {
-		public StringList(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var parser = new Parser(variables);
+		public StringList(BufferedReader sr) {
+			var parser = new Parser();
 			parser.RegisterKeyword("\"\"", _ => { });
 			parser.RegisterRegex(CommonRegexes.String, (_, theString) =>
 				Strings.Add(theString)
 			);
-			parser.RegisterRegex(CommonRegexes.Variable, (_, varStr) => {
-				var value = parser.ResolveVariable(varStr).ToString();
-				if (value is null) {
-					Logger.Warn($"StringList: variable {varStr} resolved to null value!");
-				} else {
-					Strings.Add(value);
-				}
-			});
 			parser.RegisterRegex(CommonRegexes.QuotedString, (_, theString) =>
 				Strings.Add(StringUtils.RemQuotes(theString))
 			);
@@ -130,13 +122,9 @@ namespace commonItems {
 	}
 
 	public class IntList {
-		public IntList(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var parser = new Parser(variables);
+		public IntList(BufferedReader sr) {
+			var parser = new Parser();
 			parser.RegisterRegex(CommonRegexes.Integer, (_, intString) => Ints.Add(int.Parse(intString)));
-			parser.RegisterRegex(CommonRegexes.InterpolatedExpression, (_, expr) => {
-				var value = (int)parser.EvaluateExpression(expr);
-				Ints.Add(value);
-			});
 			parser.RegisterRegex(CommonRegexes.QuotedInteger, (_, intString) => {
 				// remove quotes
 				intString = intString[1..^1];
@@ -148,13 +136,9 @@ namespace commonItems {
 	}
 
 	public class LongList {
-		public LongList(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var parser = new Parser(variables);
+		public LongList(BufferedReader sr) {
+			var parser = new Parser();
 			parser.RegisterRegex(CommonRegexes.Integer, (_, longString) => Longs.Add(long.Parse(longString)));
-			parser.RegisterRegex(CommonRegexes.InterpolatedExpression, (_, expr) => {
-				var value = (long)(int)parser.EvaluateExpression(expr);
-				Longs.Add(value);
-			});
 			parser.RegisterRegex(CommonRegexes.QuotedInteger, (_, longString) => {
 				// remove quotes
 				longString = longString[1..^1];
@@ -166,13 +150,9 @@ namespace commonItems {
 	}
 
 	public class ULongList {
-		public ULongList(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var parser = new Parser(variables);
+		public ULongList(BufferedReader sr) {
+			var parser = new Parser();
 			parser.RegisterRegex(CommonRegexes.Integer, (_, ulongString) => ULongs.Add(ulong.Parse(ulongString)));
-			parser.RegisterRegex(CommonRegexes.InterpolatedExpression, (_, expr) => {
-				var value = (ulong)(int)parser.EvaluateExpression(expr);
-				ULongs.Add(value);
-			});
 			parser.RegisterRegex(CommonRegexes.QuotedInteger, (_, ulongString) => {
 				// remove quotes
 				ulongString = ulongString[1..^1];
@@ -184,15 +164,11 @@ namespace commonItems {
 	}
 
 	public class DoubleList {
-		public DoubleList(BufferedReader sr, Dictionary<string, object>? variables = null) {
-			var parser = new Parser(variables);
+		public DoubleList(BufferedReader sr) {
+			var parser = new Parser();
 			parser.RegisterRegex(CommonRegexes.Float, (_, floatString) =>
 				Doubles.Add(double.Parse(floatString, NumberStyles.Any, CultureInfo.InvariantCulture))
 			);
-			parser.RegisterRegex(CommonRegexes.InterpolatedExpression, (_, expr) => {
-				var value = (double)parser.EvaluateExpression(expr);
-				Doubles.Add(value);
-			});
 			parser.RegisterRegex(CommonRegexes.QuotedFloat, (_, floatString) => {
 				// remove quotes
 				floatString = floatString[1..^1];

--- a/commonItems/ParserHelpers.cs
+++ b/commonItems/ParserHelpers.cs
@@ -44,11 +44,10 @@ namespace commonItems {
 	}
 	public class SingleString {
 		public SingleString(BufferedReader sr) {
-			var parser = new Parser();
 			// remove equals
-			parser.GetNextTokenWithoutMatching(sr);
+			Parser.GetNextTokenWithoutMatching(sr);
 
-			var token = parser.GetNextTokenWithoutMatching(sr);
+			var token = Parser.GetNextTokenWithoutMatching(sr);
 			if (token is null) {
 				Logger.Error("SingleString: next token not found!");
 			} else {
@@ -116,6 +115,17 @@ namespace commonItems {
 			parser.RegisterRegex(CommonRegexes.QuotedString, (_, theString) =>
 				Strings.Add(StringUtils.RemQuotes(theString))
 			);
+			if (sr.Variables.Count > 0) {
+				parser.RegisterRegex(CommonRegexes.Variable, (reader, varStr) => {
+					var value = reader.ResolveVariable(varStr).ToString();
+					if (value is null) {
+						Logger.Warn($"StringList: variable {varStr} resolved to null value!");
+					} else {
+						Strings.Add(value);
+					}
+				});
+			}
+
 			parser.ParseStream(sr);
 		}
 		public List<string> Strings { get; } = new();
@@ -130,6 +140,13 @@ namespace commonItems {
 				intString = intString[1..^1];
 				Ints.Add(int.Parse(intString));
 			});
+			if (sr.Variables.Count > 0) {
+				parser.RegisterRegex(CommonRegexes.InterpolatedExpression, (reader, expr) => {
+					var value = (int)reader.EvaluateExpression(expr);
+					Ints.Add(value);
+				});
+			}
+
 			parser.ParseStream(sr);
 		}
 		public List<int> Ints { get; } = new();
@@ -144,6 +161,13 @@ namespace commonItems {
 				longString = longString[1..^1];
 				Longs.Add(long.Parse(longString));
 			});
+			if (sr.Variables.Count > 0) {
+				parser.RegisterRegex(CommonRegexes.InterpolatedExpression, (reader, expr) => {
+					var value = (long)(int)reader.EvaluateExpression(expr);
+					Longs.Add(value);
+				});
+			}
+
 			parser.ParseStream(sr);
 		}
 		public List<long> Longs { get; } = new();
@@ -158,6 +182,13 @@ namespace commonItems {
 				ulongString = ulongString[1..^1];
 				ULongs.Add(ulong.Parse(ulongString));
 			});
+			if (sr.Variables.Count > 0) {
+				parser.RegisterRegex(CommonRegexes.InterpolatedExpression, (reader, expr) => {
+					var value = (ulong)(int)reader.EvaluateExpression(expr);
+					ULongs.Add(value);
+				});
+			}
+
 			parser.ParseStream(sr);
 		}
 		public List<ulong> ULongs { get; } = new();
@@ -174,6 +205,13 @@ namespace commonItems {
 				floatString = floatString[1..^1];
 				Doubles.Add(double.Parse(floatString, NumberStyles.Any, CultureInfo.InvariantCulture));
 			});
+			if (sr.Variables.Count > 0) {
+				parser.RegisterRegex(CommonRegexes.InterpolatedExpression, (reader, expr) => {
+					var value = (double)reader.EvaluateExpression(expr);
+					Doubles.Add(value);
+				});
+			}
+
 			parser.ParseStream(sr);
 		}
 		public List<double> Doubles { get; } = new();


### PR DESCRIPTION
This means we no longer need to pass `Dictionary<string, object>? variables` as parameter to methods `BufferedReader.GetString()`, `BufferedReader.GetInts()` etc. in order to correctly handle variables.
Makes more sense to store variables in the reader rather than parser, too.