### PR TITLE
Remove SingleInt, SingleLong, SingleULong, SingleDouble

### DIFF
--- a/commonItems.UnitTests/ParserHelperTests.cs
+++ b/commonItems.UnitTests/ParserHelperTests.cs
@@ -108,24 +108,21 @@ namespace commonItems.UnitTests {
 		}
 
 		[Fact]
-		public void SingleIntGetsIntAfterEquals() {
-			var input = new BufferedReader(" = 1");
-			var theInteger = new SingleInt(input);
-			Assert.Equal(1, theInteger.Int);
+		public void GetIntGetsIntAfterEquals() {
+			var reader = new BufferedReader(" = 1");
+			Assert.Equal(1, reader.GetInt());
 		}
 
 		[Fact]
-		public void SingleIntGetsNegativeIntAfterEquals() {
-			var input = new BufferedReader(" = -1");
-			var theInteger = new SingleInt(input);
-			Assert.Equal(-1, theInteger.Int);
+		public void GetIntGetsNegativeIntAfterEquals() {
+			var reader = new BufferedReader(" = -1");
+			Assert.Equal(-1, reader.GetInt());
 		}
 
 		[Fact]
 		public void SingleIntGetsQuotedIntAfterEquals() {
-			var input = new BufferedReader(" = \"-1\"");
-			var theInteger = new SingleInt(input);
-			Assert.Equal(-1, theInteger.Int);
+			var reader = new BufferedReader(" = \"-1\"");
+			Assert.Equal(-1, reader.GetInt());
 		}
 
 		[Fact]
@@ -133,10 +130,10 @@ namespace commonItems.UnitTests {
 			var output = new StringWriter();
 			Console.SetOut(output);
 
-			var input = new BufferedReader("= foo");
-			var theInteger = new SingleInt(input);
+			var reader = new BufferedReader("= foo");
+			var theInteger = reader.GetInt();
 			Assert.Equal("[WARN] Could not convert string foo to int!", output.ToString().TrimEnd());
-			Assert.Equal(0, theInteger.Int);
+			Assert.Equal(0, theInteger);
 		}
 
 		[Fact]
@@ -182,28 +179,26 @@ namespace commonItems.UnitTests {
 		}
 
 		[Fact]
-		public void SingleDoubleGetsDoubleAfterEquals() {
-			var input = new BufferedReader(" = 1.25");
-			var theDouble = new SingleDouble(input);
-			Assert.Equal(1.25, theDouble.Double);
+		public void GetDoubleGetsDoubleAfterEquals() {
+			var reader = new BufferedReader(" = 1.25");
+			Assert.Equal(1.25, reader.GetDouble());
 		}
 
 		[Fact]
-		public void SingleDoubleGetsQuotedDoubleAfterEquals() {
-			var input = new BufferedReader(" = \"1.25\"");
-			var theDouble = new SingleDouble(input);
-			Assert.Equal(1.25, theDouble.Double);
+		public void GetDoubleGetsQuotedDoubleAfterEquals() {
+			var reader = new BufferedReader(" = \"1.25\"");
+			Assert.Equal(1.25, reader.GetDouble());
 		}
 
 		[Fact]
-		public void SingleDoubleLogsNotMatchingInput() {
+		public void GetDoubleLogsNotMatchingInput() {
 			var output = new StringWriter();
 			Console.SetOut(output);
 
-			var input = new BufferedReader("= \"345.345 foo\"");
-			var theDouble = new SingleDouble(input);
+			var reader = new BufferedReader("= \"345.345 foo\"");
+			var theDouble = reader.GetDouble();
 			Assert.Equal("[WARN] Could not convert string 345.345 foo to double!", output.ToString().TrimEnd());
-			Assert.Equal(0, theDouble.Double);
+			Assert.Equal(0, theDouble);
 		}
 
 		[Fact]
@@ -462,73 +457,67 @@ namespace commonItems.UnitTests {
 		}
 
 		[Fact]
-		public void SingleLongGetsLongAfterEquals() {
+		public void GetLongGetsLongAfterEquals() {
 			var reader = new BufferedReader(" = 123456789012345");
-			var theLong = new SingleLong(reader).Long;
 
-			Assert.Equal(123456789012345, theLong);
+			Assert.Equal(123456789012345, reader.GetLong());
 		}
 
 		[Fact]
-		public void SingleLongGetsNegativeLongAfterEquals() {
+		public void GetLongGetsNegativeLongAfterEquals() {
 			var reader = new BufferedReader(" = -123456789012345");
-			var theLong = new SingleLong(reader).Long;
 
-			Assert.Equal(-123456789012345, theLong);
+			Assert.Equal(-123456789012345, reader.GetLong());
 		}
 
 		[Fact]
-		public void SingleULongGetsULongAfterEquals() {
+		public void GetULongGetsULongAfterEquals() {
 			var reader = new BufferedReader(" = 299792458000000000");
-			var theULong = new SingleULong(reader).ULong;
 
-			Assert.Equal((ulong)299792458000000000, theULong);
+			Assert.Equal((ulong)299792458000000000, reader.GetULong());
 		}
 
 		[Fact]
-		public void SingleLongGetsQuotedLongAfterEquals() {
+		public void GetLongGetsQuotedLongAfterEquals() {
 			var reader = new BufferedReader(@"= ""123456789012345""");
-			var theLong = new SingleLong(reader).Long;
 
-			Assert.Equal(123456789012345, theLong);
+			Assert.Equal(123456789012345, reader.GetLong());
 		}
 
 		[Fact]
-		public void SingleLongGetsQuotedNegativeLongAfterEquals() {
+		public void GetLongGetsQuotedNegativeLongAfterEquals() {
 			var reader = new BufferedReader(@"= ""-123456789012345""");
-			var theLong = new SingleLong(reader).Long;
 
-			Assert.Equal(-123456789012345, theLong);
+			Assert.Equal(-123456789012345, reader.GetLong());
 		}
 
 		[Fact]
-		public void SingleULongGetsQuotedUlongAfterEquals() {
+		public void GetULongGetsQuotedUlongAfterEquals() {
 			var reader = new BufferedReader(@"= ""123456789012345""");
-			var theULong = new SingleULong(reader).ULong;
 
-			Assert.Equal((ulong)123456789012345, theULong);
+			Assert.Equal((ulong)123456789012345, reader.GetULong());
 		}
 
 		[Fact]
-		public void SingleLongLogsInvalidInput() {
+		public void GetLongLogsInvalidInput() {
 			var reader = new BufferedReader("= foo");
 
 			var output = new StringWriter();
 			Console.SetOut(output);
-			var theLong = new SingleLong(reader).Long;
+			var theLong = reader.GetLong();
 
 			Assert.Contains("Could not convert string foo to long!", output.ToString());
 			Assert.Equal(0, theLong);
 		}
 
 		[Fact]
-		public void SingleULongLogsInvalidInput() {
+		public void GetULongLogsInvalidInput() {
 			var reader = new BufferedReader("= foo");
 
 			var output = new StringWriter();
 			Console.SetOut(output);
 
-			var theULong = new SingleULong(reader).ULong;
+			var theULong = reader.GetULong();
 
 			Assert.Contains("Could not convert string foo to ulong!", output.ToString());
 			Assert.Equal((ulong)0, theULong);

--- a/commonItems.UnitTests/ParserHelperTests.cs
+++ b/commonItems.UnitTests/ParserHelperTests.cs
@@ -120,13 +120,13 @@ namespace commonItems.UnitTests {
 		}
 
 		[Fact]
-		public void SingleIntGetsQuotedIntAfterEquals() {
+		public void GetIntGetsQuotedIntAfterEquals() {
 			var reader = new BufferedReader(" = \"-1\"");
 			Assert.Equal(-1, reader.GetInt());
 		}
 
 		[Fact]
-		public void SingleIntLogsInvalidInput() {
+		public void GetIntLogsInvalidInput() {
 			var output = new StringWriter();
 			Console.SetOut(output);
 

--- a/commonItems/BufferedReader.cs
+++ b/commonItems/BufferedReader.cs
@@ -1,6 +1,7 @@
 ﻿using NCalc;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -72,8 +73,7 @@ namespace commonItems {
 			}
 		}
 
-		public void Skip(uint numberOfBytes) // not present in StreamReader
-		{
+		public void Skip(uint numberOfBytes) { // not present in StreamReader
 			for (uint i = 0; i < numberOfBytes; ++i) {
 				Read();
 			}
@@ -87,16 +87,40 @@ namespace commonItems {
 			return new SingleString(this).String;
 		}
 		public int GetInt() {
-			return new SingleInt(this).Int;
+			var intStr = StringUtils.RemQuotes(GetString());
+			if (int.TryParse(intStr, out int theInt)) {
+				return theInt;
+			}
+
+			Logger.Warn($"Could not convert string {intStr} to int!");
+			return 0;
 		}
 		public long GetLong() {
-			return new SingleLong(this).Long;
+			var longStr = StringUtils.RemQuotes(GetString());
+			if (long.TryParse(longStr, out long theLong)) {
+				return theLong;
+			}
+
+			Logger.Warn($"Could not convert string {longStr} to long!");
+			return 0;
 		}
 		public ulong GetULong() {
-			return new SingleULong(this).ULong;
+			var ulongStr = StringUtils.RemQuotes(GetString());
+			if (ulong.TryParse(ulongStr, out ulong theULong)) {
+				return theULong;
+			}
+
+			Logger.Warn($"Could not convert string {ulongStr} to ulong!");
+			return 0;
 		}
 		public double GetDouble() {
-			return new SingleDouble(this).Double;
+			var doubleStr = StringUtils.RemQuotes(GetString());
+			if (double.TryParse(doubleStr, NumberStyles.Any, CultureInfo.InvariantCulture, out double theDouble)) {
+				return theDouble;
+			}
+
+			Logger.Warn($"Could not convert string {doubleStr} to double!");
+			return 0;
 		}
 		public List<string> GetStrings() {
 			return new StringList(this).Strings;

--- a/commonItems/ParserHelpers.cs
+++ b/commonItems/ParserHelpers.cs
@@ -57,54 +57,6 @@ namespace commonItems {
 		public string String { get; } = "";
 	}
 
-	public class SingleInt {
-		public SingleInt(BufferedReader sr) {
-			var intStr = StringUtils.RemQuotes(sr.GetString());
-			if (!int.TryParse(intStr, out int theInt)) {
-				Logger.Warn($"Could not convert string {intStr} to int!");
-				return;
-			}
-			Int = theInt;
-		}
-		public int Int { get; }
-	}
-
-	public class SingleLong {
-		public SingleLong(BufferedReader sr) {
-			var longStr = StringUtils.RemQuotes(sr.GetString());
-			if (!long.TryParse(longStr, out long theLong)) {
-				Logger.Warn($"Could not convert string {longStr} to long!");
-				return;
-			}
-			Long = theLong;
-		}
-		public long Long { get; }
-	}
-
-	public class SingleULong {
-		public SingleULong(BufferedReader sr) {
-			var ulongStr = StringUtils.RemQuotes(sr.GetString());
-			if (!ulong.TryParse(ulongStr, out ulong theULong)) {
-				Logger.Warn($"Could not convert string {ulongStr} to ulong!");
-				return;
-			}
-			ULong = theULong;
-		}
-		public ulong ULong { get; }
-	}
-
-	public class SingleDouble {
-		public SingleDouble(BufferedReader sr) {
-			var doubleStr = StringUtils.RemQuotes(sr.GetString());
-			if (!double.TryParse(doubleStr, NumberStyles.Any, CultureInfo.InvariantCulture, out double theDouble)) {
-				Logger.Warn($"Could not convert string {doubleStr} to double!");
-				return;
-			}
-			Double = theDouble;
-		}
-		public double Double { get; }
-	}
-
 	public class StringList {
 		public StringList(BufferedReader sr) {
 			var parser = new Parser();


### PR DESCRIPTION
Logic from their constructors has been moved into BufferedReader.GetInt(), BufferedReader.GetLong() etc.
This enforces the prettier way of getting values. Should improve parsing speed a bit, too.