### PR TITLE
Use GameFinder.StoreHandlers.Steam package for more reliable game location

### DIFF
--- a/commonItems/commonItems.csproj
+++ b/commonItems/commonItems.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GameFinder.StoreHandlers.Steam" Version="1.7.2" />
     <PackageReference Include="log4net" Version="2.0.14" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="NCalcSync" Version="3.0.0" />


### PR DESCRIPTION
"there's a library for that"

The `InstallLocation` value from `[...]Uninstall\Steam App {steamId}` gets outdated when a user moves game installation through Steam. `SteamHandler` parses Steam's appmanifest files instead, so it returns valid path.