### PR TITLE
Use ModFilesystem in `ParseGameFolder` and `ParseGameFile`

### DIFF
--- a/commonItems.UnitTests/Collections/OrderedSetTests.cs
+++ b/commonItems.UnitTests/Collections/OrderedSetTests.cs
@@ -108,7 +108,7 @@ public class OrderedSetTests {
 		
 		Assert.True(set.IsSupersetOf(subset));
 		Assert.True(set.IsSupersetOf(set));
-		Assert.False(set.IsSubsetOf(otherSet));
+		Assert.False(set.IsSupersetOf(otherSet));
 	}
 
 	[Fact]
@@ -147,5 +147,13 @@ public class OrderedSetTests {
 		set.UnionWith(list);
 
 		set.Should().Equal(1, 2, 3, 4, 5, 6);
+	}
+
+	[Fact]
+	public void RemoveWhereRemovesElementsMatchingPredicate() {
+		var set = new OrderedSet<int> {1, 2, 3, 4, 5, 6, 7, 8, 9};
+		set.RemoveWhere(i=>i%3==1);
+
+		set.Should().Equal(2, 3, 5, 6, 8, 9);
 	}
 }

--- a/commonItems.UnitTests/Mods/ModFilesystemTests.cs
+++ b/commonItems.UnitTests/Mods/ModFilesystemTests.cs
@@ -1,26 +1,25 @@
 ﻿using commonItems.Mods;
 using FluentAssertions;
-using System;
 using System.Collections.Generic;
+using Xunit;
 
 namespace commonItems.UnitTests.Mods;
 
-using Xunit;
 
 public class ModFilesystemTests {
 	[Fact]
 	public void MissingFileReturnsNull() {
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new Mod[] { });
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new Mod[] { });
 
-		var filePath = modFileSystem.GetActualFileLocation("test_folder/non_file.txt");
+		var filePath = modFS.GetActualFileLocation("test_folder/non_file.txt");
 		Assert.Null(filePath);
 	}
 	
 	[Fact]
 	public void FileCanBeFoundInGameRoot() {
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new Mod[] { });
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new Mod[] { });
 
-		var filePath = modFileSystem.GetActualFileLocation("test_folder/test_file.txt");
+		var filePath = modFS.GetActualFileLocation("test_folder/test_file.txt");
 		Assert.NotNull(filePath);
 		Assert.Equal("TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/test_file.txt", filePath);
 	}
@@ -28,10 +27,9 @@ public class ModFilesystemTests {
 	[Fact]
 	public void FileIsReplacedByMod() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
 
-		var filePath = modFileSystem.GetActualFileLocation("test_folder/test_file.txt");
+		var filePath = modFS.GetActualFileLocation("test_folder/test_file.txt");
 		Assert.NotNull(filePath);
 		Assert.Equal("TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt", filePath);
 	}
@@ -40,10 +38,10 @@ public class ModFilesystemTests {
 	public void LatestModDeterminesFile() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		var filePath = modFileSystem.GetActualFileLocation("test_folder/test_file.txt");
+		var filePath = modFS.GetActualFileLocation("test_folder/test_file.txt");
 		Assert.NotNull(filePath);
 		Assert.Equal("TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt", filePath);
 	}
@@ -53,10 +51,10 @@ public class ModFilesystemTests {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
 		var modThree = new Mod("Mod Three", "TestFiles/ModFilesystem/GetActualFileLocation/mod_three");
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo, modThree});
 
-		var filePath = modFileSystem.GetActualFileLocation("test_folder/test_file.txt");
+		var filePath = modFS.GetActualFileLocation("test_folder/test_file.txt");
 		Assert.NotNull(filePath);
 		Assert.Equal("TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt", filePath);
 	}
@@ -67,10 +65,10 @@ public class ModFilesystemTests {
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
 		var modThree = new Mod("Mod Three", "TestFiles/ModFilesystem/GetActualFileLocation/mod_three", new string[] { },
 			new HashSet<string> {"test_folder"});
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo, modThree});
 
-		var filePath = modFileSystem.GetActualFileLocation("test_folder/test_file.txt");
+		var filePath = modFS.GetActualFileLocation("test_folder/test_file.txt");
 		Assert.Null(filePath);
 	}
 	
@@ -80,29 +78,27 @@ public class ModFilesystemTests {
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
 		var modThree = new Mod("Mod Three", "TestFiles/ModFilesystem/GetActualFileLocation/mod_three", new string[] { },
 			new HashSet<string> {"test_fold"});
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo, modThree});
 
-		var filePath = modFileSystem.GetActualFileLocation("test_folder/test_file.txt");
+		var filePath = modFS.GetActualFileLocation("test_folder/test_file.txt");
 		Assert.NotNull(filePath);
 		Assert.Equal("TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt", filePath);
 	}
 
 	[Fact]
 	public void MissingFolderReturnsNull() {
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
-		var filePath = modFileSystem.GetActualFolderLocation("test_folder/non_folder");
+		var filePath = modFS.GetActualFolderLocation("test_folder/non_folder");
 		Assert.Null(filePath);
 	}
 	
 	[Fact]
 	public void FolderCanBeFoundInGameRoot() {
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
-		var filePath = modFileSystem.GetActualFolderLocation("test_folder/deeper_folder");
+		var filePath = modFS.GetActualFolderLocation("test_folder/deeper_folder");
 		Assert.NotNull(filePath);
 		Assert.Equal("TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/deeper_folder", filePath);
 	}
@@ -110,10 +106,9 @@ public class ModFilesystemTests {
 	[Fact]
 	public void FolderIsReplacedByMod() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
 
-		var filePath = modFileSystem.GetActualFolderLocation("test_folder/deeper_folder");
+		var filePath = modFS.GetActualFolderLocation("test_folder/deeper_folder");
 		Assert.NotNull(filePath);
 		Assert.Equal("TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/deeper_folder", filePath);
 	}
@@ -122,10 +117,10 @@ public class ModFilesystemTests {
 	public void LatestModDeterminesFolder() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		var filePath = modFileSystem.GetActualFolderLocation("test_folder/deeper_folder");
+		var filePath = modFS.GetActualFolderLocation("test_folder/deeper_folder");
 		Assert.NotNull(filePath);
 		Assert.Equal("TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder", filePath);
 	}
@@ -135,10 +130,10 @@ public class ModFilesystemTests {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
 		var modThree = new Mod("Mod Three", "TestFiles/ModFilesystem/GetActualFileLocation/mod_three");
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo, modThree});
 
-		var filePath = modFileSystem.GetActualFolderLocation("test_folder/deeper_folder");
+		var filePath = modFS.GetActualFolderLocation("test_folder/deeper_folder");
 		Assert.NotNull(filePath);
 		Assert.Equal("TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder", filePath);
 	}
@@ -149,27 +144,25 @@ public class ModFilesystemTests {
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
 		var modThree = new Mod("Mod Three", "TestFiles/ModFilesystem/GetActualFileLocation/mod_three", new string[] { },
 			new HashSet<string> {"test_folder/"});
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo, modThree});
 
-		var filePath = modFileSystem.GetActualFolderLocation("test_folder/deeper_folder");
+		var filePath = modFS.GetActualFolderLocation("test_folder/deeper_folder");
 		Assert.Null(filePath);
 	}
 	
 	[Fact]
 	public void NoFilesInMissingDirectory() {
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
-		modFileSystem.GetAllFilesInFolder("/non_folder").Should().BeEmpty();
+		modFS.GetAllFilesInFolder("/non_folder").Should().BeEmpty();
 	}
 
 	[Fact]
 	public void FilesInGameRootAreFound() {
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
-		modFileSystem.GetAllFilesInFolder("test_folder").Should().Equal(
+		modFS.GetAllFilesInFolder("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/test_file.txt");
 	}
@@ -177,10 +170,9 @@ public class ModFilesystemTests {
 	[Fact]
 	public void ModFilesAddToAndReplaceGameRootFiles() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
 
-		modFileSystem.GetAllFilesInFolder("test_folder").Should().Equal(
+		modFS.GetAllFilesInFolder("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt");
@@ -190,10 +182,10 @@ public class ModFilesystemTests {
 	public void ModFilesAddToAndReplaceEarlierModFiles() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		modFileSystem.GetAllFilesInFolder("test_folder").Should().Equal(
+		modFS.GetAllFilesInFolder("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
@@ -205,10 +197,10 @@ public class ModFilesystemTests {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two", new string[] { },
 			new HashSet<string>() {"test_folder"});
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		modFileSystem.GetAllFilesInFolder("test_folder").Should().Equal(
+		modFS.GetAllFilesInFolder("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
 	}
@@ -223,10 +215,9 @@ public class ModFilesystemTests {
 	
 	[Fact]
 	public void FoldersInGameRootAreFound() {
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
-		modFileSystem.GetAllSubfolders("test_folder").Should().Equal(
+		modFS.GetAllSubfolders("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/deeper_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder");
 	}
@@ -234,10 +225,9 @@ public class ModFilesystemTests {
 	[Fact]
 	public void ModFoldersAddToAndReplaceGameRootFolders() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
 
-		modFileSystem.GetAllSubfolders("test_folder").Should().Equal(
+		modFS.GetAllSubfolders("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/deeper_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder");
@@ -247,10 +237,10 @@ public class ModFilesystemTests {
 	public void ModFoldersAddToAndReplaceEarlierModFolders() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		modFileSystem.GetAllSubfolders("test_folder").Should().Equal(
+		modFS.GetAllSubfolders("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder",
@@ -262,71 +252,62 @@ public class ModFilesystemTests {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two", new string[] { },
 			new HashSet<string> {"test_folder"});
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		modFileSystem.GetAllSubfolders("test_folder").Should().Equal(
+		modFS.GetAllSubfolders("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder");
 	}
 	
 	[Fact]
 	public void NoFilesInMissingDirectoryTree() {
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
-		modFileSystem.GetAllFilesInFolderRecursive("/non_folder").Should().BeEmpty();
+		modFS.GetAllFilesInFolderRecursive("/non_folder").Should().BeEmpty();
 	}
 
 	[Fact]
 	public void FilesInGameRootAndSubfoldersAreFound() {
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
-		// TODO: CHECK IN WHAT ORDER THEY SHOULD BE
-		throw new NotImplementedException();
-		modFileSystem.GetAllFilesInFolderRecursive("test_folder").Should().BeEquivalentTo(
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/deeper_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt",
+		modFS.GetAllFilesInFolderRecursive("test_folder").Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt");
+			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/deeper_folder/dummy.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt");
 	}
 
 	[Fact]
 	public void ModFilesAndSubfoldersAddToAndReplaceGameRootFiles() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
-		var modFileSystem =
-			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
 
-		// TODO: CHECK IN WHAT ORDER THEY SHOULD BE
-		throw new NotImplementedException();
-		modFileSystem.GetAllFilesInFolderRecursive("test_folder").Should().BeEquivalentTo(
+		modFS.GetAllFilesInFolderRecursive("test_folder").Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/deeper_folder/dummy.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt");
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder/dummy.txt");
 	}
 	
 	[Fact]
 	public void ModFilesAndSubfoldersAddToAndReplaceEarlierModFiles() {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two");
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		// TODO: CHECK IN WHAT ORDER THEY SHOULD BE
-		throw new NotImplementedException();
-		modFileSystem.GetAllFilesInFolderRecursive("test_folder").Should().BeEquivalentTo(
+		modFS.GetAllFilesInFolderRecursive("test_folder").Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt");
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt");
 	}
 
 	[Fact]
@@ -334,15 +315,13 @@ public class ModFilesystemTests {
 		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
 		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two", new string[] { },
 			new HashSet<string> {"test_folder"});
-		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		// TODO: CHECK IN WHAT ORDER THEY SHOULD BE
-		throw new NotImplementedException();
-		modFileSystem.GetAllFilesInFolderRecursive("test_folder").Should().BeEquivalentTo(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt",
+		modFS.GetAllFilesInFolderRecursive("test_folder").Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt");
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt");
 	}
 }

--- a/commonItems.UnitTests/Mods/ModFilesystemTests.cs
+++ b/commonItems.UnitTests/Mods/ModFilesystemTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 
 namespace commonItems.UnitTests.Mods;
 
-
 public class ModFilesystemTests {
 	[Fact]
 	public void MissingFileReturnsNull() {

--- a/commonItems.UnitTests/Mods/ModFilesystemTests.cs
+++ b/commonItems.UnitTests/Mods/ModFilesystemTests.cs
@@ -1,5 +1,6 @@
 ﻿using commonItems.Mods;
 using FluentAssertions;
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -203,6 +204,31 @@ public class ModFilesystemTests {
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
 	}
+
+	private class CustomPrecedenceComparer : IComparer<string> {
+		// longest path first
+		public int Compare(String? x, String? y) {
+			var xLength = x!.Length;
+			var yLength = y!.Length;
+			if (xLength > yLength) {
+				return -1;
+			}
+			return xLength == yLength ? 0 : 1;
+		}
+	}
+
+	[Fact]
+	public void GetAllFilesInFolderCanBeCalledWithCustomFilePrecedenceComparer() {
+		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
+		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two", new string[] { },
+			new HashSet<string>() {"test_folder"});
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+			new[] {modOne, modTwo});
+
+		modFS.GetAllFilesInFolder("test_folder", new CustomPrecedenceComparer()).Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
+	}
 	
 	[Fact]
 	public void NoFoldersInMissingDirectory() {
@@ -257,6 +283,19 @@ public class ModFilesystemTests {
 		modFS.GetAllSubfolders("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder");
+	}
+
+	[Fact]
+	public void GetAllSubfoldersCanBeCalledWithCustomFolderPrecedenceComparer() {
+		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
+		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two", new string[] { },
+			new HashSet<string> {"test_folder"});
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+			new[] {modOne, modTwo});
+
+		modFS.GetAllSubfolders("test_folder", new CustomPrecedenceComparer()).Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder");
 	}
 	
 	[Fact]
@@ -322,5 +361,20 @@ public class ModFilesystemTests {
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt");
+	}
+
+	[Fact]
+	public void GetAllFilesInFolderRecursiveCanBeCalledWithCustomFilePrecedenceComparer() {
+		var modOne = new Mod("Mod One", "TestFiles/ModFilesystem/GetActualFileLocation/mod_one");
+		var modTwo = new Mod("Mod Two", "TestFiles/ModFilesystem/GetActualFileLocation/mod_two", new string[] { },
+			new HashSet<string> {"test_folder"});
+		var modFS = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
+			new[] {modOne, modTwo});
+
+		modFS.GetAllFilesInFolderRecursive("test_folder", new CustomPrecedenceComparer()).Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
 	}
 }

--- a/commonItems.UnitTests/Mods/ModFilesystemTests.cs
+++ b/commonItems.UnitTests/Mods/ModFilesystemTests.cs
@@ -1,5 +1,6 @@
 ﻿using commonItems.Mods;
 using FluentAssertions;
+using System;
 using System.Collections.Generic;
 
 namespace commonItems.UnitTests.Mods;
@@ -168,9 +169,9 @@ public class ModFilesystemTests {
 		var modFileSystem =
 			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
-		modFileSystem.GetAllFilesInFolder("test_folder").Should().BeEquivalentTo(
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt");
+		modFileSystem.GetAllFilesInFolder("test_folder").Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/test_file.txt");
 	}
 
 	[Fact]
@@ -179,10 +180,10 @@ public class ModFilesystemTests {
 		var modFileSystem =
 			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
 
-		modFileSystem.GetAllFilesInFolder("test_folder").Should().BeEquivalentTo(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt",
+		modFileSystem.GetAllFilesInFolder("test_folder").Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt");
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/test_file.txt");
 	}
 	
 	[Fact]
@@ -192,11 +193,11 @@ public class ModFilesystemTests {
 		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		modFileSystem.GetAllFilesInFolder("test_folder").Should().BeEquivalentTo(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
+		modFileSystem.GetAllFilesInFolder("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt");
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/root_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
 	}
 	
 	[Fact]
@@ -207,9 +208,9 @@ public class ModFilesystemTests {
 		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		modFileSystem.GetAllFilesInFolder("test_folder").Should().BeEquivalentTo(
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt",
-			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt");
+		modFileSystem.GetAllFilesInFolder("test_folder").Should().Equal(
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_file.txt",
+			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/test_file.txt");
 	}
 	
 	[Fact]
@@ -225,7 +226,7 @@ public class ModFilesystemTests {
 		var modFileSystem =
 			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
-		modFileSystem.GetAllSubfolders("test_folder").Should().BeEquivalentTo(
+		modFileSystem.GetAllSubfolders("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/deeper_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder");
 	}
@@ -236,7 +237,7 @@ public class ModFilesystemTests {
 		var modFileSystem =
 			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
 
-		modFileSystem.GetAllSubfolders("test_folder").Should().BeEquivalentTo(
+		modFileSystem.GetAllSubfolders("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/deeper_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder");
@@ -249,7 +250,7 @@ public class ModFilesystemTests {
 		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		modFileSystem.GetAllSubfolders("test_folder").Should().BeEquivalentTo(
+		modFileSystem.GetAllSubfolders("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/mod_one_folder",
@@ -264,7 +265,7 @@ public class ModFilesystemTests {
 		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
-		modFileSystem.GetAllSubfolders("test_folder").Should().BeEquivalentTo(
+		modFileSystem.GetAllSubfolders("test_folder").Should().Equal(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder");
 	}
@@ -282,6 +283,8 @@ public class ModFilesystemTests {
 		var modFileSystem =
 			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new List<Mod>());
 
+		// TODO: CHECK IN WHAT ORDER THEY SHOULD BE
+		throw new NotImplementedException();
 		modFileSystem.GetAllFilesInFolderRecursive("test_folder").Should().BeEquivalentTo(
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/deeper_folder/dummy.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt",
@@ -295,6 +298,8 @@ public class ModFilesystemTests {
 		var modFileSystem =
 			new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root", new[] {modOne});
 
+		// TODO: CHECK IN WHAT ORDER THEY SHOULD BE
+		throw new NotImplementedException();
 		modFileSystem.GetAllFilesInFolderRecursive("test_folder").Should().BeEquivalentTo(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_one/test_folder/deeper_folder/dummy.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt",
@@ -311,6 +316,8 @@ public class ModFilesystemTests {
 		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
+		// TODO: CHECK IN WHAT ORDER THEY SHOULD BE
+		throw new NotImplementedException();
 		modFileSystem.GetAllFilesInFolderRecursive("test_folder").Should().BeEquivalentTo(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/game_root/test_folder/game_folder/dummy.txt",
@@ -330,6 +337,8 @@ public class ModFilesystemTests {
 		var modFileSystem = new ModFilesystem("TestFiles/ModFilesystem/GetActualFileLocation/game_root",
 			new[] {modOne, modTwo});
 
+		// TODO: CHECK IN WHAT ORDER THEY SHOULD BE
+		throw new NotImplementedException();
 		modFileSystem.GetAllFilesInFolderRecursive("test_folder").Should().BeEquivalentTo(
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/deeper_folder/dummy.txt",
 			"TestFiles/ModFilesystem/GetActualFileLocation/mod_two/test_folder/mod_two_folder/dummy.txt",

--- a/commonItems.UnitTests/ParserTests.cs
+++ b/commonItems.UnitTests/ParserTests.cs
@@ -330,6 +330,7 @@ public class ParserTests {
 	public void ParserParsesGameFolderInVanillaAndMods() {
 		const string gamePath = "TestFiles/CK3";
 		var mods = new List<Mod> { new("cool_mod", "TestFiles/mod/themod") };
+		var modFS = new ModFilesystem(gamePath, mods);
 
 		var foundGovernments = new List<string>();
 		var parser = new Parser();
@@ -337,7 +338,8 @@ public class ParserTests {
 			foundGovernments.Add(govName);
 			ParserHelpers.IgnoreItem(reader);
 		});
-		parser.ParseGameFolder(Path.Combine("common", "governments"), gamePath, "txt", mods, recursive: false);
+
+		parser.ParseGameFolder("common/governments", modFS, "txt", recursive: false);
 		Assert.Collection(foundGovernments,
 			gov1 => Assert.Equal("tribal_federation", gov1),
 			gov2 => Assert.Equal("tribal_modded", gov2));
@@ -347,6 +349,7 @@ public class ParserTests {
 	public void ParserRecursivelyParsesGameFolderInVanillaAndMods() {
 		const string gamePath = "TestFiles/CK3";
 		var mods = new List<Mod> { new("cool_mod", "TestFiles/mod/themod") };
+		var modFS = new ModFilesystem(gamePath, mods);
 
 		var foundGovernments = new List<string>();
 		var parser = new Parser();
@@ -354,7 +357,8 @@ public class ParserTests {
 			foundGovernments.Add(govName);
 			ParserHelpers.IgnoreItem(reader);
 		});
-		parser.ParseGameFolder("common/governments", gamePath, "txt", mods, recursive: true);
+
+		parser.ParseGameFolder("common/governments", modFS, "txt", recursive: true);
 		Assert.Collection(foundGovernments,
 			gov1 => Assert.Equal("aristocratic_republic", gov1),
 			gov2 => Assert.Equal("tribal_federation", gov2),

--- a/commonItems.UnitTests/ParserTests.cs
+++ b/commonItems.UnitTests/ParserTests.cs
@@ -1,4 +1,5 @@
 using commonItems.Mods;
+using FluentAssertions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -328,9 +329,9 @@ public class ParserTests {
 
 	[Fact]
 	public void ParserParsesGameFolderInVanillaAndMods() {
-		const string gamePath = "TestFiles/CK3";
+		const string gameRoot = "TestFiles/CK3/game";
 		var mods = new List<Mod> { new("cool_mod", "TestFiles/mod/themod") };
-		var modFS = new ModFilesystem(gamePath, mods);
+		var modFS = new ModFilesystem(gameRoot, mods);
 
 		var foundGovernments = new List<string>();
 		var parser = new Parser();
@@ -340,16 +341,17 @@ public class ParserTests {
 		});
 
 		parser.ParseGameFolder("common/governments", modFS, "txt", recursive: false);
-		Assert.Collection(foundGovernments,
-			gov1 => Assert.Equal("tribal_federation", gov1),
-			gov2 => Assert.Equal("tribal_modded", gov2));
+		foundGovernments.Should().Equal(
+			"tribal_modded", // mod_tribal_govs.txt in mod
+			"tribal_federation" // vanilla_governments.txt in game
+		);
 	}
 
 	[Fact]
 	public void ParserRecursivelyParsesGameFolderInVanillaAndMods() {
-		const string gamePath = "TestFiles/CK3";
+		const string gameRoot = "TestFiles/CK3/game";
 		var mods = new List<Mod> { new("cool_mod", "TestFiles/mod/themod") };
-		var modFS = new ModFilesystem(gamePath, mods);
+		var modFS = new ModFilesystem(gameRoot, mods);
 
 		var foundGovernments = new List<string>();
 		var parser = new Parser();
@@ -359,20 +361,23 @@ public class ParserTests {
 		});
 
 		parser.ParseGameFolder("common/governments", modFS, "txt", recursive: true);
-		Assert.Collection(foundGovernments,
-			gov1 => Assert.Equal("aristocratic_republic", gov1),
-			gov2 => Assert.Equal("tribal_federation", gov2),
-			gov3 => Assert.Equal("tribal_modded", gov3),
-			gov4 => Assert.Equal("constitutional_monarchy", gov4));
+
+		foundGovernments.Should().Equal(
+			"tribal_modded", // mod_tribal_govs.txt in mod
+			"tribal_federation", // vanilla_governments.txt in game
+			"constitutional_monarchy", // monarchy/mod_monarchy_govs.txt in mod
+			"aristocratic_republic" // republic/republic_governments.txt in game
+		);
 	}
 
 	[Fact]
 	public void ParserParsesGameFileInVanillaAndMods() {
-		const string gamePath = "TestFiles/CK3";
+		const string gameRoot = "TestFiles/CK3/game";
 		var mods = new List<Mod> {
 			new("mod1", "TestFiles/mod/themod"),
 			new("mod2", "TestFiles/mod/mod2")
 		};
+		var modFS = new ModFilesystem(gameRoot, mods);
 
 		var foundAreas = new List<string>();
 		var parser = new Parser();
@@ -380,10 +385,14 @@ public class ParserTests {
 			foundAreas.Add(areaName);
 			ParserHelpers.IgnoreItem(reader);
 		});
-		parser.ParseGameFile("map_data/areas.txt", gamePath, mods);
-
-		Assert.Collection(foundAreas,
-			area1 => Assert.Equal("vanilla1_area", area1),
-			area2 => Assert.Equal("themod_area", area2));
+		
+		parser.ParseGameFile("map_data/areas.txt", modFS);
+		// File exists in game and mod1. Mod's version takes precedence.
+		foundAreas.Should().Equal("themod_area");
+		
+		foundAreas.Clear();
+		parser.ParseGameFile("map_data/areas2.txt", modFS);
+		// File exists only in game.
+		foundAreas.Should().Equal("vanilla1_area2");
 	}
 }

--- a/commonItems.UnitTests/TestFiles/CK3/game/map_data/areas2.txt
+++ b/commonItems.UnitTests/TestFiles/CK3/game/map_data/areas2.txt
@@ -1,0 +1,1 @@
+vanilla1_area2 = {}

--- a/commonItems/Collections/ExtensionMethods.cs
+++ b/commonItems/Collections/ExtensionMethods.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/commonItems/Collections/ExtensionMethods.cs
+++ b/commonItems/Collections/ExtensionMethods.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace commonItems.Collections; 
+
+public static class ExtensionMethods {
+	public static OrderedSet<T> ToOrderedSet<T>(this IEnumerable<T> enumerable) where T : notnull {
+		return new OrderedSet<T>(enumerable);
+	}
+	
+	public static void RemoveWhere<T>(this ICollection<T> collection, Func<T, bool> predicate) {
+		foreach (T item in collection.ToList().Where(predicate)) {
+			collection.Remove(item);
+		}
+	}
+}

--- a/commonItems/Collections/OrderedSet.cs
+++ b/commonItems/Collections/OrderedSet.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -108,6 +109,12 @@ public class OrderedSet<T> : ISet<T> where T : notnull {
 		dictionary.Remove(item);
 		linkedList.Remove(node!);
 		return true;
+	}
+	
+	public void RemoveWhere(Func<T, bool> predicate) {
+		foreach (T item in this.ToList().Where(predicate)) {
+			Remove(item);
+		}
 	}
 
 	public IEnumerator<T> GetEnumerator() => linkedList.GetEnumerator();

--- a/commonItems/Collections/OrderedSet.cs
+++ b/commonItems/Collections/OrderedSet.cs
@@ -110,12 +110,6 @@ public class OrderedSet<T> : ISet<T> where T : notnull {
 		linkedList.Remove(node!);
 		return true;
 	}
-	
-	public void RemoveWhere(Func<T, bool> predicate) {
-		foreach (T item in this.ToList().Where(predicate)) {
-			Remove(item);
-		}
-	}
 
 	public IEnumerator<T> GetEnumerator() => linkedList.GetEnumerator();
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/commonItems/Collections/OrderedSet.cs
+++ b/commonItems/Collections/OrderedSet.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/commonItems/Mods/ModFilesystem.cs
+++ b/commonItems/Mods/ModFilesystem.cs
@@ -1,7 +1,6 @@
 ﻿using commonItems.Collections;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 

--- a/commonItems/Mods/ModFilesystem.cs
+++ b/commonItems/Mods/ModFilesystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using commonItems.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -33,19 +34,15 @@ public class ModFilesystem {
 	/// </summary>
 	/// <param name="gameRoot">Points at the game's root folder, and all paths in the lookup functions will be based on that root.</param>
 	/// <param name="mods">A list of the mods applied, in increasing order of precedence. Later mods will override files in the game root or earlier mods, and their
-	/// replace_paths will block earlier mods and the game It is the caller's responsibility to sort the mods appropriately</param>
+	/// replace_paths will block earlier mods and the game.
+	/// It is the caller's responsibility to sort the mods appropriately
+	/// </param>
 	public ModFilesystem(string gameRoot, IEnumerable<Mod> mods) {
 		this.gameRoot = gameRoot;
 		this.mods = mods.ToList();
 	}
 
-	// lookup functions
-	//[[nodiscard]] std::optional<std::string> GetActualFileLocation(const std::string& path) const;
-	//[[nodiscard]] std::optional<std::string> GetActualFolderLocation(const std::string& path) const;
-	//[[nodiscard]] std::set<std::string> GetAllFilesInFolder(const std::string& path) const;
-	//[[nodiscard]] std::set<std::string> GetAllSubfolders(const std::string& path) const;
-	//[[nodiscard]] std::set<std::string> GetAllFilesInFolderRecursive(const std::string& path) const;
-
+	#region lookup functions
 	public string? GetActualFileLocation(string path) {
 		foreach (var mod in Enumerable.Reverse(mods)) {
 			var pathInMod = Path.Combine(mod.Path, path).Replace('\\', '/');
@@ -78,28 +75,76 @@ public class ModFilesystem {
 		return Directory.Exists(pathInGameRoot) ? pathInGameRoot : null;
 	}
 
-	public ISet<string> GetAllFilesInFolder(string path) {
-		var fullFiles = new HashSet<string>();
-		var foundFiles = new HashSet<string>();
+	public OrderedSet<string> GetAllFilesInFolder(string path) {
+		var foundFiles = new SortedDictionary<string, string>(); // <relative path, full path>
 
 		foreach (var mod in Enumerable.Reverse(mods)) {
 			var pathInMod = Path.Combine(mod.Path, path).Replace('\\', '/');
 			foreach (var newFile in SystemUtils.GetAllFilesInFolder(pathInMod)) {
-				if (foundFiles.Contains(newFile)) {
+				if (foundFiles.ContainsKey(newFile)) {
 					continue;
 				}
 
-				foundFiles.Add(newFile);
-				fullFiles.Add( Path.Combine(pathInMod, newFile).Replace('\\', '/'));
+				var fullPath = Path.Combine(pathInMod, newFile).Replace('\\', '/');
+				foundFiles.Add(newFile, fullPath);
 			}
 
 			if (PathIsReplaced(path, mod.ReplacedFolders)) {
-				return fullFiles;
+				return new OrderedSet<string>(foundFiles.Values);
 			}
 		}
 
 		var pathInGameRoot = Path.Combine(gameRoot, path).Replace('\\', '/');
 		foreach (var newFile in SystemUtils.GetAllFilesInFolder(pathInGameRoot)) {
+			if (foundFiles.ContainsKey(newFile)) {
+				continue;
+			}
+
+			var fullPath = Path.Combine(pathInGameRoot, newFile).Replace('\\', '/');
+			foundFiles.Add(newFile, fullPath);
+		}
+
+		return new OrderedSet<string>(foundFiles.Values);
+	}
+	
+	public OrderedSet<string> GetAllSubfolders(string path) {
+		var foundFolders = new SortedDictionary<string, string>(); // <relative path, full path>
+
+		foreach (var mod in Enumerable.Reverse(mods)) {
+			var pathInMod = Path.Combine(mod.Path, path).Replace('\\', '/');
+			foreach (var newFolder in SystemUtils.GetAllSubfolders(pathInMod)) {
+				if (foundFolders.ContainsKey(newFolder)) {
+					continue;
+				}
+
+				var fullPath = Path.Combine(pathInMod, newFolder).Replace('\\', '/');
+				foundFolders.Add(newFolder, fullPath);
+			}
+
+			if (PathIsReplaced(path, mod.ReplacedFolders)) {
+				return new OrderedSet<string>(foundFolders.Values);
+			}
+		}
+
+		var pathInGameRoot = Path.Combine(gameRoot, path).Replace('\\', '/');
+		foreach (var newFolder in SystemUtils.GetAllSubfolders(pathInGameRoot)) {
+			if (foundFolders.ContainsKey(newFolder)) {
+				continue;
+			}
+
+			var fullPath = Path.Combine(pathInGameRoot, newFolder).Replace('\\', '/');
+			foundFolders.Add(newFolder, fullPath);
+		}
+
+		return new OrderedSet<string>(foundFolders.Values);
+	}
+	
+	public OrderedSet<string> GetAllFilesInFolderRecursive(string path) {
+		var fullFiles = new OrderedSet<string>();
+		var foundFiles = new OrderedSet<string>();
+
+		var pathInGameRoot = Path.Combine(gameRoot, path).Replace('\\', '/');
+		foreach (var newFile in SystemUtils.GetAllFilesInFolderRecursive(pathInGameRoot)) {
 			if (foundFiles.Contains(newFile)) {
 				continue;
 			}
@@ -108,47 +153,7 @@ public class ModFilesystem {
 			fullFiles.Add(Path.Combine(pathInGameRoot, newFile).Replace('\\', '/'));
 		}
 
-		return fullFiles;
-	}
-	
-	public ISet<string> GetAllSubfolders(string path) {
-		var fullFolders = new HashSet<string>();
-		var foundFolders = new HashSet<string>();
-
-		foreach (var mod in Enumerable.Reverse(mods)) {
-			var pathInMod = Path.Combine(mod.Path, path).Replace('\\', '/');
-			foreach (var newFolder in SystemUtils.GetAllSubfolders(pathInMod)) {
-				if (foundFolders.Contains(newFolder)) {
-					continue;
-				}
-
-				foundFolders.Add(newFolder);
-				fullFolders.Add(Path.Combine(pathInMod, newFolder).Replace('\\', '/'));
-			}
-
-			if (PathIsReplaced(path, mod.ReplacedFolders)) {
-				return fullFolders;
-			}
-		}
-
-		var pathInGameRoot = Path.Combine(gameRoot, path).Replace('\\', '/');
-		foreach (var newFolder in SystemUtils.GetAllSubfolders(pathInGameRoot)) {
-			if (foundFolders.Contains(newFolder)) {
-				continue;
-			}
-
-			foundFolders.Add(newFolder);
-			fullFolders.Add(Path.Combine(pathInGameRoot, newFolder).Replace('\\', '/'));
-		}
-
-		return fullFolders;
-	}
-	
-	public ISet<string> GetAllFilesInFolderRecursive(string path) {
-		var fullFiles = new HashSet<string>();
-		var foundFiles = new HashSet<string>();
-
-		foreach (var mod in Enumerable.Reverse(mods)) {
+		foreach (var mod in mods) {
 			var pathInMod = Path.Combine(mod.Path, path).Replace('\\', '/');
 			foreach (var newFile in SystemUtils.GetAllFilesInFolderRecursive(pathInMod)) {
 				if (foundFiles.Contains(newFile)) {
@@ -164,16 +169,7 @@ public class ModFilesystem {
 			}
 		}
 
-		var pathInGameRoot = Path.Combine(gameRoot, path).Replace('\\', '/');
-		foreach (var newFile in SystemUtils.GetAllFilesInFolderRecursive(pathInGameRoot)) {
-			if (foundFiles.Contains(newFile)) {
-				continue;
-			}
-
-			foundFiles.Add(newFile);
-			fullFiles.Add(Path.Combine(pathInGameRoot, newFile).Replace('\\', '/'));
-		}
-
 		return fullFiles;
-	} 
+	}
+	#endregion
 }

--- a/commonItems/Parser.cs
+++ b/commonItems/Parser.cs
@@ -375,10 +375,8 @@ public class Parser {
 
 	/// <summary>
 	/// Parses a game folder in both vanilla game and mods directory.
-	/// Designed for Jomini-based games.
 	/// For example:
 	///		relativePath may be "common/governments"
-	///		gamePath may be "C:\SteamLibrary\Imperator"
 	///		extensions may be "txt;text" (a list separated by semicolon)
 	/// </summary>
 	public void ParseGameFolder(string relativePath, ModFilesystem modFS, string extensions, bool recursive) {
@@ -391,29 +389,21 @@ public class Parser {
 			files = new OrderedSet<string>(modFS.GetAllFilesInFolder(relativePath));
 		}
 		files.RemoveWhere(f => !extensionSet.Contains(CommonFunctions.GetExtension(f)));
-		foreach (var file in files.Reverse()) {
+		foreach (var file in files) {
 			ParseFile(file);
 		}
 	}
 
 	/// <summary>
-	/// Parses a game file in both vanilla game and mods directory.
-	/// Designed for Jomini-based games.
+	/// Parses a game file in either vanilla game or mods directory.
 	/// For example:
 	///		relativePath may be "map_data/areas.txt"
-	///		gamePath may be "C:\SteamLibrary\Imperator"
 	/// </summary>
-	public void ParseGameFile(string relativePath, string gamePath, IEnumerable<Mod> mods) {
-		var vanillaFilePath = Path.Combine(gamePath, "game", relativePath);
-		if (File.Exists(vanillaFilePath)) {
-			ParseFile(vanillaFilePath);
-		}
-
-		foreach (var mod in mods) {
-			var modFilePath = Path.Combine(mod.Path, relativePath);
-			if (File.Exists(modFilePath)) {
-				ParseFile(modFilePath);
-			}
+	public void ParseGameFile(string relativePath, ModFilesystem modFS) {
+		var filePath = modFS.GetActualFileLocation(relativePath);
+		
+		if (File.Exists(filePath)) {
+			ParseFile(filePath);
 		}
 	}
 

--- a/commonItems/Parser.cs
+++ b/commonItems/Parser.cs
@@ -384,9 +384,9 @@ public class Parser {
 
 		OrderedSet<string> files;
 		if (recursive) {
-			files = new OrderedSet<string>(modFS.GetAllFilesInFolderRecursive(relativePath));
+			files = modFS.GetAllFilesInFolderRecursive(relativePath);
 		} else {
-			files = new OrderedSet<string>(modFS.GetAllFilesInFolder(relativePath));
+			files = modFS.GetAllFilesInFolder(relativePath);
 		}
 		files.RemoveWhere(f => !extensionSet.Contains(CommonFunctions.GetExtension(f)));
 		foreach (var file in files) {

--- a/commonItems/Parser.cs
+++ b/commonItems/Parser.cs
@@ -1,4 +1,5 @@
-﻿using commonItems.Mods;
+﻿using commonItems.Collections;
+using commonItems.Mods;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -380,23 +381,18 @@ public class Parser {
 	///		gamePath may be "C:\SteamLibrary\Imperator"
 	///		extensions may be "txt;text" (a list separated by semicolon)
 	/// </summary>
-	public void ParseGameFolder(string relativePath, string gamePath, string extensions, IEnumerable<Mod> mods, bool recursive) {
+	public void ParseGameFolder(string relativePath, ModFilesystem modFS, string extensions, bool recursive) {
 		var extensionSet = extensions.Split(';');
 
-		var vanillaPath = Path.Combine(gamePath, "game", relativePath);
-		SortedSet<string> files = recursive ? SU.GetAllFilesInFolderRecursive(vanillaPath) : SU.GetAllFilesInFolder(vanillaPath);
-		files.RemoveWhere(f => !extensionSet.Contains(CommonFunctions.GetExtension(f)));
-		foreach (string filePath in files.Select(fileName => Path.Combine(vanillaPath, fileName))) {
-			ParseFile(filePath);
+		OrderedSet<string> files;
+		if (recursive) {
+			files = new OrderedSet<string>(modFS.GetAllFilesInFolderRecursive(relativePath));
+		} else {
+			files = new OrderedSet<string>(modFS.GetAllFilesInFolder(relativePath));
 		}
-
-		foreach (var mod in mods) {
-			var modPath = Path.Combine(mod.Path, relativePath);
-			files = recursive ? SU.GetAllFilesInFolderRecursive(modPath) : SU.GetAllFilesInFolder(modPath);
-			files.RemoveWhere(f => !extensionSet.Contains(CommonFunctions.GetExtension(f)));
-			foreach (string filePath in files.Select(fileName => Path.Combine(modPath, fileName))) {
-				ParseFile(filePath);
-			}
+		files.RemoveWhere(f => !extensionSet.Contains(CommonFunctions.GetExtension(f)));
+		foreach (var file in files.Reverse()) {
+			ParseFile(file);
 		}
 	}
 


### PR DESCRIPTION
closes #146 

This required fixing the order in which ModFS's lookup functions return path collections. The order should now match how PDX games parse files. For example CK3 parsed events file in the following order:

events/a_welcome.txt
events/welcome.txt
events/religious_events/a_welcome.txt
events/religious_events/welcome.txt
events/zzz/a_welcome.txt
events/zzz/welcome.txt

So it seems that the files with least amount of folders in path take precedence, and then it's alphabetical order.
**You might want to port the paths collection order fix to C++ commonItems.**