### PR TITLE
NamedColorCollection

### DIFF
--- a/commonItems.UnitTests/NamedColorCollectionTests.cs
+++ b/commonItems.UnitTests/NamedColorCollectionTests.cs
@@ -1,0 +1,49 @@
+﻿using commonItems.Mods;
+using System.Collections.Generic;
+using Xunit;
+
+namespace commonItems.UnitTests; 
+
+public class NamedColorCollectionTests {
+	private const string GameRoot = "TestFiles/CK3/game";
+	private static List<Mod> mods = new() { new("Cool Mod", "TestFiles/mod/themod") };
+	private readonly ModFilesystem modFS = new(GameRoot, mods);
+	private readonly ColorFactory referenceColorFactory = new();
+	
+	[Fact]
+	public void CollectionDefaultsToEmpty() {
+		// ReSharper disable once CollectionNeverUpdated.Local
+		var namedColors = new NamedColorCollection();
+		
+		Assert.Empty(namedColors);
+	}
+
+	[Fact]
+	public void NamedColorsCanBeLoadedFromGameAndMods() {
+		var namedColors = new NamedColorCollection();
+		namedColors.LoadNamedColors("common/named_colors", modFS);
+		
+		Assert.Collection(namedColors,
+			kvp => {
+				Assert.Equal("antigonid_yellow", kvp.Key); // from game
+				var expectedColorReader = new BufferedReader("= rgb { 246 223 15 }");
+				Assert.Equal(referenceColorFactory.GetColor(expectedColorReader), kvp.Value);
+			},
+			kvp => {
+				Assert.Equal("ck2_black", kvp.Key); // from mod
+				var expectedColorReader = new BufferedReader("= hsv { 0 0 0.12 }");
+				Assert.Equal(referenceColorFactory.GetColor(expectedColorReader), kvp.Value);
+			},
+			kvp => {
+				Assert.Equal("delian_league_gold", kvp.Key); // from mod
+				var expectedColorReader = new BufferedReader("= rgb { 250 250 210 }");
+				Assert.Equal(referenceColorFactory.GetColor(expectedColorReader), kvp.Value);
+			},
+			kvp => {
+				Assert.Equal("pitch_black", kvp.Key); // from game, overwritten by mod
+				var expectedColorReader = new BufferedReader("= hsv { 0 0 0.15 }");
+				Assert.Equal(referenceColorFactory.GetColor(expectedColorReader), kvp.Value);
+			}
+		);
+	}
+}

--- a/commonItems.UnitTests/NamedColorCollectionTests.cs
+++ b/commonItems.UnitTests/NamedColorCollectionTests.cs
@@ -6,7 +6,7 @@ namespace commonItems.UnitTests;
 
 public class NamedColorCollectionTests {
 	private const string GameRoot = "TestFiles/CK3/game";
-	private static List<Mod> mods = new() { new("Cool Mod", "TestFiles/mod/themod") };
+	private static readonly List<Mod> mods = new() { new("Cool Mod", "TestFiles/mod/themod") };
 	private readonly ModFilesystem modFS = new(GameRoot, mods);
 	private readonly ColorFactory referenceColorFactory = new();
 	

--- a/commonItems.UnitTests/ParserHelperTests.cs
+++ b/commonItems.UnitTests/ParserHelperTests.cs
@@ -49,7 +49,7 @@ public class ParserHelperTests {
 		public Test1(BufferedReader bufferedReader) {
 			RegisterKeyword("key1", reader => value1 = reader.GetString());
 			RegisterKeyword("key2", reader => value2 = reader.GetString());
-			RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreAndLogItem);
+			IgnoreAndLogUnregisteredItems();
 			ParseStream(bufferedReader);
 		}
 	}

--- a/commonItems.UnitTests/TestFiles/CK3/game/common/named_colors/default_colors.txt
+++ b/commonItems.UnitTests/TestFiles/CK3/game/common/named_colors/default_colors.txt
@@ -1,0 +1,5 @@
+﻿# game colors
+colors = {
+	pitch_black = hsv { 0 0 0.16 }
+    antigonid_yellow = rgb { 246 223 15 }
+}

--- a/commonItems.UnitTests/TestFiles/mod/themod/common/named_colors/mod_colors.txt
+++ b/commonItems.UnitTests/TestFiles/mod/themod/common/named_colors/mod_colors.txt
@@ -1,0 +1,7 @@
+﻿# mod colors
+colors = {
+	ck2_black = hsv { 0 0 0.12 }
+	delian_league_gold = rgb { 250 250 210 }
+
+	pitch_black = hsv { 0 0 0.15 } # overwrites game color
+}

--- a/commonItems.sln.DotSettings
+++ b/commonItems.sln.DotSettings
@@ -4,6 +4,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BOM/@EntryIndexedValue">BOM</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DB/@EntryIndexedValue">DB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PDX/@EntryIndexedValue">PDX</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=antigonid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=chalcedonian/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=formattable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Imperator/@EntryIndexedValue">True</s:Boolean>

--- a/commonItems/Color.cs
+++ b/commonItems/Color.cs
@@ -195,4 +195,6 @@ public class Color : IPDXSerializable {
 	public double[] HsvComponents { get; } = {
 		0, 0, 0
 	};
+
+	public override string ToString() => OutputRgb();
 }

--- a/commonItems/ColorFactory.cs
+++ b/commonItems/ColorFactory.cs
@@ -13,7 +13,7 @@ public class ColorFactory {
 		if (token is null) {
 			throw new FormatException("Cannot get color without token");
 		}
-		token = StringUtils.RemQuotes(token);
+		token = token.RemQuotes();
 		switch (token) {
 			case "rgb": {
 				var rgb = reader.GetInts();

--- a/commonItems/ColorFactory.cs
+++ b/commonItems/ColorFactory.cs
@@ -93,7 +93,7 @@ public class ColorFactory {
 		NamedColors[name] = GetColor(reader);
 	}
 
-	public void AddNamedColorDict(Dictionary<string, Color> colorMap) {
+	public void AddNamedColorDict(IDictionary<string, Color> colorMap) {
 		foreach (var (key, value) in colorMap) {
 			NamedColors[key] = value;
 		}

--- a/commonItems/ConverterVersion.cs
+++ b/commonItems/ConverterVersion.cs
@@ -44,7 +44,7 @@ public class ConverterVersion {
 		parser.RegisterKeyword("maxTarget", reader =>
 			MaxTarget = new GameVersion(reader.GetString())
 		);
-		parser.RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreItem);
+		parser.IgnoreUnregisteredItems();
 	}
 
 	public string GetDescription() {

--- a/commonItems/GameVersion.cs
+++ b/commonItems/GameVersion.cs
@@ -54,7 +54,7 @@ public class GameVersion {
 		parser.RegisterKeyword("second", reader => secondPart = reader.GetInt());
 		parser.RegisterKeyword("third", reader => thirdPart = reader.GetInt());
 		parser.RegisterKeyword("forth", reader => fourthPart = reader.GetInt());
-		parser.RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreAndLogItem);
+		parser.IgnoreAndLogUnregisteredItems();
 		parser.ParseStream(gameVersionReader);
 		
 		FirstPart = firstPart;

--- a/commonItems/Mods/ModParser.cs
+++ b/commonItems/Mods/ModParser.cs
@@ -42,6 +42,6 @@ public class ModParser : Parser {
 		RegisterRegex("path|archive", reader => Path = reader.GetString());
 		RegisterKeyword("dependencies", reader => Dependencies.UnionWith(reader.GetStrings()));
 		RegisterKeyword("replace_path", reader => ReplacedPaths.Add(reader.GetString()));
-		RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreItem);
+		IgnoreUnregisteredItems();
 	}
 }

--- a/commonItems/NamedColorCollection.cs
+++ b/commonItems/NamedColorCollection.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace commonItems; 
 
-public class NamedColorCollection : Dictionary<string, Color> {
+public class NamedColorCollection : SortedDictionary<string, Color> {
 	public void LoadNamedColors(string relativePath, ModFilesystem modFilesystem) {
 		var colorsParser = new Parser();
 		colorsParser.RegisterRegex(CommonRegexes.String, (reader, colorName) => {

--- a/commonItems/NamedColorCollection.cs
+++ b/commonItems/NamedColorCollection.cs
@@ -1,0 +1,22 @@
+﻿using commonItems.Mods;
+using System.Collections.Generic;
+
+namespace commonItems; 
+
+public class NamedColorCollection : Dictionary<string, Color> {
+	public void LoadNamedColors(string relativePath, ModFilesystem modFilesystem) {
+		var colorsParser = new Parser();
+		colorsParser.RegisterRegex(CommonRegexes.String, (reader, colorName) => {
+			this[colorName] = new ColorFactory().GetColor(reader);
+		});
+		colorsParser.IgnoreAndLogUnregisteredItems();
+		
+		var parser = new Parser();
+		parser.RegisterKeyword("colors", reader => {
+			colorsParser.ParseStream(reader);
+		});
+		parser.IgnoreAndLogUnregisteredItems();
+		
+		parser.ParseGameFolder(relativePath, modFilesystem, "txt", recursive: true);
+	}
+}

--- a/commonItems/Parser.cs
+++ b/commonItems/Parser.cs
@@ -115,6 +115,12 @@ public class Parser {
 	public void RegisterRegex(Regex regex, SimpleDel del) {
 		registeredRules[new RegisteredRegex(regex)] = new OneArgDelegate(del);
 	}
+	public void IgnoreUnregisteredItems() {
+		registeredRules[new RegisteredRegex(CommonRegexes.Catchall)] = new TwoArgDelegate(ParserHelpers.IgnoreAndLogItem);
+	}
+	public void IgnoreAndLogUnregisteredItems() {
+		registeredRules[new RegisteredRegex(CommonRegexes.Catchall)] = new TwoArgDelegate(ParserHelpers.IgnoreAndLogItem);
+	}
 
 	public void ClearRegisteredRules() {
 		registeredRules.Clear();


### PR DESCRIPTION
For reading `common/named_colors`, which seems a common thing in new games.

Also added `IgnoreAndLogUnregisteredItems` and `IgnoreUnregisteredItems` methods to Parser, because I hate writing `RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreAndLogItem);` or `RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreItem);` for every single parser.