### PR TITLE
Handle RGB colors with float values

### DIFF
--- a/commonItems.UnitTests/ColorTests.cs
+++ b/commonItems.UnitTests/ColorTests.cs
@@ -284,6 +284,15 @@ public class ColorTests {
 	}
 
 	[Fact]
+	public void ColorCanBeInitializedFromStreamInRgbWithFloats() {
+		var reader = new BufferedReader("= rgb { 64.2 128.4 128.6 }");
+		var color = new ColorFactory().GetColor(reader);
+		Assert.Equal(64, color.R);
+		Assert.Equal(128, color.G);
+		Assert.Equal(128, color.B);
+	}
+
+	[Fact]
 	public void ColorInitializationRequiresThreeComponentsWhenRgb() {
 		var reader = new BufferedReader("= rgb { 64 128 }");
 		Assert.Throws<FormatException>(() => new ColorFactory().GetColor(reader));

--- a/commonItems/ColorFactory.cs
+++ b/commonItems/ColorFactory.cs
@@ -8,11 +8,11 @@ public class ColorFactory {
 	public Dictionary<string, Color> NamedColors { get; } = new();
 
 	private Color GetRgbColor(BufferedReader reader) {
-		var rgb = reader.GetInts();
+		var rgb = reader.GetDoubles();
 		if (rgb.Count != 3) {
 			throw new FormatException("Color has wrong number of components");
 		}
-		return new Color(rgb[0], rgb[1], rgb[2]);
+		return new Color((int)rgb[0], (int)rgb[1], (int)rgb[2]);
 	}
 	private Color GetHexColor(BufferedReader reader) {
 		var hex = reader.GetStrings()[0];


### PR DESCRIPTION
In an Imperator mod I found this:
```
lombardy_color = rgb { 153.6 153.6 204.8 }
```
The game doesn't seem to complain, so it doesn't hurt to support it. The floats are simply cast to ints.