### PR TITLE
Replace 4 external dependencies with standard library usage

### DIFF
--- a/commonItems.UnitTests/ToOrdinalSuffixTests.cs
+++ b/commonItems.UnitTests/ToOrdinalSuffixTests.cs
@@ -53,6 +53,19 @@ public sealed class ToOrdinalSuffixTests {
 		Assert.Equal(expectedSuffix, 2.ToOrdinalSuffix(languageName));
 	}
 
+	[Theory]
+	[InlineData(1, "ENGLISH", "st")]
+	[InlineData(2, "French", "e")]
+	[InlineData(2, "PoRtUgUeSe", "º")]
+	public void ToOrdinalSuffixLanguageLookupIsCaseInsensitive(int number, string languageName, string expectedSuffix) {
+		Assert.Equal(expectedSuffix, number.ToOrdinalSuffix(languageName));
+	}
+
+	[Fact]
+	public void FrenchOneGivesEr() {
+		Assert.Equal("er", 1.ToOrdinalSuffix("french"));
+	}
+
 	[Fact]
 	public void SuffixForUnsupportedLanguageDefaultsToEnglish() {
 		Assert.Equal("th", 5.ToOrdinalSuffix("zoomer"));

--- a/commonItems/CommonFunctions.cs
+++ b/commonItems/CommonFunctions.cs
@@ -7,8 +7,6 @@ using GameFinder.Wine;
 using NexusMods.Paths;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -75,13 +73,13 @@ public static class CommonFunctions {
 	}
 	
 	// Ordinal suffix lookup table by language
-	private static readonly Dictionary<string, Func<int, string>> OrdinalSuffixRules = new() {
+	private static readonly Dictionary<string, Func<int, string>> OrdinalSuffixRules = new(StringComparer.OrdinalIgnoreCase) {
 		{ "english", GetEnglishOrdinalSuffix },
 		{ "catalan", _ => "n" },
 		{ "chinese", _ => "." },
 		{ "simp_chinese", _ => "." },
 		{ "dutch", _ => "e" },
-		{ "french", _ => "e" },
+		{ "french", GetFrenchOrdinalSuffix },
 		{ "italian", _ => "º" },
 		{ "japanese", _ => "番" },
 		{ "portuguese", _ => "º" },
@@ -108,6 +106,11 @@ public static class CommonFunctions {
 	private static string GetSpanishOrdinalSuffix(int number) {
 		// Spanish uses "º" for masculine and "ª" for feminine. Default to masculine.
 		return "º";
+	}
+
+	private static string GetFrenchOrdinalSuffix(int number) {
+		// Keep API gender-neutral: use masculine form for 1st (1er), then "e" for 2+
+		return number == 1 ? "er" : "e";
 	}
 
 	public static string ToOrdinalSuffix(this int number) {

--- a/commonItems/CommonFunctions.cs
+++ b/commonItems/CommonFunctions.cs
@@ -4,9 +4,9 @@ using GameFinder.StoreHandlers.Steam;
 using GameFinder.StoreHandlers.GOG;
 using GameFinder.StoreHandlers.Steam.Models.ValueTypes;
 using GameFinder.Wine;
-using IcgSoftware.IntToOrdinalNumber;
 using NexusMods.Paths;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -74,20 +74,53 @@ public static class CommonFunctions {
 		};
 	}
 	
+	// Ordinal suffix lookup table by language
+	private static readonly Dictionary<string, Func<int, string>> OrdinalSuffixRules = new() {
+		{ "english", GetEnglishOrdinalSuffix },
+		{ "catalan", _ => "n" },
+		{ "chinese", _ => "." },
+		{ "simp_chinese", _ => "." },
+		{ "dutch", _ => "e" },
+		{ "french", _ => "e" },
+		{ "italian", _ => "º" },
+		{ "japanese", _ => "番" },
+		{ "portuguese", _ => "º" },
+		{ "spanish", GetSpanishOrdinalSuffix },
+	};
+
+	private static string GetEnglishOrdinalSuffix(int number) {
+		var lastDigit = number % 10;
+		var lastTwoDigits = number % 100;
+
+		// Handle teens (11-13) which use "th"
+		if (lastTwoDigits is >= 11 and <= 13) {
+			return "th";
+		}
+
+		return lastDigit switch {
+			1 => "st",
+			2 => "nd",
+			3 => "rd",
+			_ => "th"
+		};
+	}
+
+	private static string GetSpanishOrdinalSuffix(int number) {
+		// Spanish uses "º" for masculine and "ª" for feminine. Default to masculine.
+		return "º";
+	}
+
 	public static string ToOrdinalSuffix(this int number) {
 		return number.ToOrdinalSuffix("english");
 	}
+
 	public static string ToOrdinalSuffix(this int number, string languageName) {
-		var languageTag = LanguageNameToIetfTag(languageName);
-		CultureInfo cultureInfo;
-		try {
-			cultureInfo = CultureInfo.GetCultureInfo(languageTag);
-		} catch(CultureNotFoundException e) {
-			Logger.Warn($"Failed to get ordinal number suffix for culture {languageTag}, defaulting to English. Details: {e.Message}");
-			cultureInfo = CultureInfo.GetCultureInfo(LanguageNameToIetfTag("english"));
+		if (OrdinalSuffixRules.TryGetValue(languageName, out var suffixRule)) {
+			return suffixRule(number);
 		}
-		
-		return number.ToOrdinalNumber(cultureInfo).Replace(number.ToString(CultureInfo.InvariantCulture), "");
+
+		Logger.Warn($"Language '{languageName}' not supported for ordinal suffixes, defaulting to English.");
+		return GetEnglishOrdinalSuffix(number);
 	}
 	
 	[Obsolete($"Use {nameof(ToRomanNumeral)}() extension method instead")]

--- a/commonItems/Linguistics/AdjectiveGenerationRules.tt
+++ b/commonItems/Linguistics/AdjectiveGenerationRules.tt
@@ -1,17 +1,17 @@
 ﻿<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ output extension=".Generated.cs" #>
 
-using Open.Collections;
+using System.Collections.Generic;
 
 namespace commonItems.Linguistics;
 
 public static partial class StringExtensions {
-	private static readonly OrderedDictionary<string, string> AdjectiveRules = new() {
+	private static readonly System.Collections.Generic.OrderedDictionary<string, string> AdjectiveRules = new() {
 		<#@ include file="adjective_rules.txt" #>
 
 	};
 	// Same as adjective rules, but are matched multiple times.
-	private static readonly OrderedDictionary<string, string> AdjectiveRewriteRules = new() {
+	private static readonly System.Collections.Generic.OrderedDictionary<string, string> AdjectiveRewriteRules = new() {
 		<#@ include file="adjective_rewrite_rules.txt" #>
 
 	};

--- a/commonItems/Linguistics/StringExtensions.cs
+++ b/commonItems/Linguistics/StringExtensions.cs
@@ -1,5 +1,5 @@
-﻿using Open.Collections;
-using System;
+﻿using System;
+using System.Collections.Generic;
 
 namespace commonItems.Linguistics;
 

--- a/commonItems/Mods/ModLoader.cs
+++ b/commonItems/Mods/ModLoader.cs
@@ -1,8 +1,8 @@
 ﻿using commonItems.Exceptions;
-using ICSharpCode.SharpZipLib.Zip;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -251,7 +251,7 @@ public sealed partial class ModLoader {
 
 	private static bool ExtractZip(string archive, string path) {
 		try {
-			new FastZip().ExtractZip(archive, path, ".*");
+			ZipFile.ExtractToDirectory(archive, path, overwriteFiles: true);
 		} catch (Exception e) {
 			Logger.Error($"Extracting zip failed: {e}");
 			return false;

--- a/commonItems/Parser.cs
+++ b/commonItems/Parser.cs
@@ -1,5 +1,4 @@
 ﻿using commonItems.Mods;
-using Open.Collections;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -398,7 +397,7 @@ public class Parser {
 	///		relativePath may be "common/governments"
 	///		extensions may be "txt;text" (a list separated by semicolon)
 	/// </summary>
-	public void ParseGameFolder(string relativePath, ModFilesystem modFS, string extensions, bool recursive, bool logFilePaths = false, bool parallel = false) {
+	public void ParseGameFolder(string relativePath, ModFilesystem modFS, string extensions, bool recursive, bool logFilePaths = false) {
 		var extensionSet = new HashSet<string>(extensions.Split(';'), StringComparer.OrdinalIgnoreCase);
 
 		List<ModFSFileInfo> files;
@@ -407,19 +406,12 @@ public class Parser {
 		} else {
 			files = modFS.GetAllFilesInFolder(relativePath);
 		}
-		var parseTargets = new List<string>(files.Count);
 		foreach (var file in files) {
 			if (!extensionSet.Contains(CommonFunctions.GetExtension(file.RelativePath))) {
 				continue;
 			}
-			parseTargets.Add(file.AbsolutePath);
-		}
 
-		parseTargets.ForEach(ProcessFile, allowParallel: parallel);
-
-		return;
-
-		void ProcessFile(string filePath) {
+			var filePath = file.AbsolutePath;
 			if (logFilePaths) {
 				Logger.Debug($"Parsing file: {filePath}");
 			}

--- a/commonItems/commonItems.csproj
+++ b/commonItems/commonItems.csproj
@@ -6,7 +6,7 @@
 
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>PGCG.$(AssemblyName)</PackageId>
-    <Version>22.0.1</Version>
+    <Version>23.0.0</Version>
     <Authors>PGCG</Authors>
     <PackageProjectUrl>https://github.com/ParadoxGameConverters/commonItems.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ParadoxGameConverters/commonItems.NET</RepositoryUrl>
@@ -39,12 +39,8 @@
     <PackageReference Include="GameFinder.StoreHandlers.GOG" Version="4.9.0" />
     <PackageReference Include="GameFinder.StoreHandlers.Steam" Version="4.9.0" />
     <PackageReference Include="Hardware.Info.Aot" Version="101.1.1.1" />
-    <PackageReference Include="IcgSoftware.IntToOrdinalNumber" Version="1.0.0" />
     <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="Mono.TextTemplating" Version="3.0.0" />
     <PackageReference Include="NCalcSync" Version="5.12.0" />
-    <PackageReference Include="Open.Collections" Version="4.2.0" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <TextTemplate Include="**\*.tt" />
     <Generated Include="**\*.Generated.cs" />
   </ItemGroup>


### PR DESCRIPTION
Also removed the optional `parallel` parameter from `ParseGameFolder`. Most parsing we perform relies on the correct order.